### PR TITLE
feat(documents): feed filter

### DIFF
--- a/packages/documents/graphql/schema-types.js
+++ b/packages/documents/graphql/schema-types.js
@@ -17,6 +17,7 @@ type Meta {
   twitterDescription: String
   publishDate: DateTime
   template: String
+  feed: Boolean
   kind: String
   format: String
   credits: JSON

--- a/packages/documents/graphql/schema.js
+++ b/packages/documents/graphql/schema.js
@@ -6,7 +6,7 @@ schema {
 
 type queries {
   # (pre)published documents
-  documents: [Document]!
+  documents(feed: Boolean): [Document]!
   # (pre)published document
   document(slug: String!): Document
 }


### PR DESCRIPTION
affects: @orbiting/backend-modules-documents

Also had a ready user filter ready:
```js
      if (creditUserId) {
        documents = documents.filter(d => {
          const userIds = (d.meta.credits || [])
            .filter(c => c.type === 'link')
            .map(c => c.url.split('~')[1])
            .filter(Boolean)
          return userIds.includes(creditUserId)
        })
      }
```

However should go onto `User.documents` which was a bit too complex for a first PR. And didn't want to open the PublicUser vs. User pandora box.