### PR TITLE
Document: Resolve Links

### DIFF
--- a/packages/auth/lib/checkUsername.js
+++ b/packages/auth/lib/checkUsername.js
@@ -14,6 +14,10 @@ module.exports = async (username, me, pgdb) => {
     }))
   }
 
+  if (!username.match(/^[.a-z0-9]+$/)) {
+    throw new Error(t('api/checkUsername/invalid'))
+  }
+
   const id = await pgdb.public.users.findOneFieldOnly({username}, 'id')
   if (!id || (me && me.id === id)) {
     return true

--- a/packages/auth/lib/translations.json
+++ b/packages/auth/lib/translations.json
@@ -1,5 +1,5 @@
 {
-  "updated": "2017-12-19T11:04:58.317Z",
+  "updated": "2017-12-23T19:46:52.017Z",
   "title": "live",
   "data": [
     {
@@ -41,6 +41,10 @@
     {
       "key": "api/checkUsername/max",
       "value": "Username, maximal {count} Zeichen"
+    },
+    {
+      "key": "api/checkUsername/invalid",
+      "value": "Username, nur a-z, 0-9 und . erlaubt"
     },
     {
       "key": "api/checkUsername/taken",

--- a/packages/auth/lib/translations.json
+++ b/packages/auth/lib/translations.json
@@ -1,5 +1,5 @@
 {
-  "updated": "2017-12-23T19:46:52.017Z",
+  "updated": "2017-12-26T00:34:56.432Z",
   "title": "live",
   "data": [
     {
@@ -36,19 +36,19 @@
     },
     {
       "key": "api/checkUsername/min",
-      "value": "Username, minimal {count} Zeichen"
+      "value": "Benutzername, minimal {count} Zeichen"
     },
     {
       "key": "api/checkUsername/max",
-      "value": "Username, maximal {count} Zeichen"
+      "value": "Benutzername, maximal {count} Zeichen"
     },
     {
       "key": "api/checkUsername/invalid",
-      "value": "Username, nur a-z, 0-9 und . erlaubt"
+      "value": "Benutzername, nur a-z, 0-9 und . erlaubt"
     },
     {
       "key": "api/checkUsername/taken",
-      "value": "Username, nicht mehr verfügbar"
+      "value": "Benutzername, nicht mehr verfügbar"
     }
   ]
 }

--- a/packages/documents/README.md
+++ b/packages/documents/README.md
@@ -11,4 +11,8 @@ used by:
 # This var restricts the documents query to the specified roles.
 # Without it beeing specified, documents are server to everybody.
 DOCUMENTS_RESTRICT_TO_ROLES=editor,member
+# Used to resolve inter document links
+GITHUB_LOGIN
+# Used to resolve user profile links
+FRONTEND_BASE_URL
 ```

--- a/packages/documents/graphql/resolvers/Document.js
+++ b/packages/documents/graphql/resolvers/Document.js
@@ -1,0 +1,29 @@
+const visit = require('unist-util-visit')
+const { createAutoSlug } = require('../../lib/resolve')
+const { getMeta } = require('../../lib/meta')
+
+module.exports = {
+  content (doc, args, context, info) {
+    // we only do auto slugging when in a published documents context
+    // - this is easiest dedectable by _all being present from documents resolver
+    // - alt check info.path for documents / document being the root
+    //   https://gist.github.com/tpreusse/f79833a023706520da53647f9c61c7f6
+    if (doc._all) {
+      const autoSlug = createAutoSlug(doc._all)
+
+      visit(doc.content, 'link', node => {
+        node.url = autoSlug(node.url)
+      })
+      visit(doc.content, 'zone', node => {
+        if (node.data) {
+          node.data.url = autoSlug(node.data.url)
+        }
+      })
+    }
+
+    return doc.content
+  },
+  meta (doc, args, context, info) {
+    return getMeta(doc)
+  }
+}

--- a/packages/documents/graphql/resolvers/Document.js
+++ b/packages/documents/graphql/resolvers/Document.js
@@ -1,5 +1,7 @@
 const visit = require('unist-util-visit')
-const { createAutoSlug } = require('../../lib/resolve')
+const {
+  createUrlReplacer
+} = require('../../lib/resolve')
 const { getMeta } = require('../../lib/meta')
 
 module.exports = {
@@ -9,14 +11,17 @@ module.exports = {
     // - alt check info.path for documents / document being the root
     //   https://gist.github.com/tpreusse/f79833a023706520da53647f9c61c7f6
     if (doc._all) {
-      const autoSlug = createAutoSlug(doc._all)
+      const urlReplacer = createUrlReplacer(
+        doc._all,
+        doc._usernames
+      )
 
       visit(doc.content, 'link', node => {
-        node.url = autoSlug(node.url)
+        node.url = urlReplacer(node.url)
       })
       visit(doc.content, 'zone', node => {
         if (node.data) {
-          node.data.url = autoSlug(node.data.url)
+          node.data.url = urlReplacer(node.data.url)
         }
       })
     }
@@ -24,6 +29,18 @@ module.exports = {
     return doc.content
   },
   meta (doc, args, context, info) {
-    return getMeta(doc)
+    const meta = getMeta(doc)
+    if (doc._all) {
+      const urlReplacer = createUrlReplacer(
+        doc._all,
+        doc._usernames
+      )
+      meta.credits
+        .filter(c => c.type === 'link')
+        .forEach(c => {
+          c.url = urlReplacer(c.url)
+        })
+    }
+    return meta
   }
 }

--- a/packages/documents/graphql/resolvers/_queries/document.js
+++ b/packages/documents/graphql/resolvers/_queries/document.js
@@ -1,9 +1,8 @@
 const getDocuments = require('./documents')
 
-module.exports = async (_, args, { user, redis }) => {
+module.exports = async (_, args, context) => {
   const { slug } = args
 
-  return getDocuments(_, {
-    slug
-  }, { user, redis }).then(docCon => docCon.nodes[0])
+  return getDocuments(_, { slug }, context)
+    .then(docCon => docCon.nodes[0])
 }

--- a/packages/documents/graphql/resolvers/_queries/documents.js
+++ b/packages/documents/graphql/resolvers/_queries/documents.js
@@ -73,8 +73,7 @@ module.exports = async (_, args, { user, redis, pgdb }) => {
             'username !=': null
           },
           {
-            fields: ['id', 'username'],
-            limit: userIds.length
+            fields: ['id', 'username']
           }
         )
         : []

--- a/packages/documents/graphql/schema-types.js
+++ b/packages/documents/graphql/schema-types.js
@@ -19,7 +19,8 @@ type Meta {
   template: String
   feed: Boolean
   kind: String
-  format: String
+  format: Document
+  dossier: Document
   credits: JSON
 }
 

--- a/packages/documents/graphql/schema.js
+++ b/packages/documents/graphql/schema.js
@@ -8,6 +8,9 @@ type queries {
   # (pre)published documents
   documents(
     feed: Boolean
+    dossier: String
+    format: String
+    template: String
     first: Int
     last: Int
     before: String

--- a/packages/documents/lib/meta.js
+++ b/packages/documents/lib/meta.js
@@ -1,0 +1,40 @@
+const visit = require('unist-util-visit')
+const { createResolver } = require('./resolve')
+
+const getMeta = doc => {
+  if (doc._meta) {
+    return doc._meta
+  }
+
+  const resolvedFields = {}
+
+  // see _all note in Document.content resolver
+  if (doc._all) {
+    const resolver = createResolver(doc._all)
+
+    resolvedFields.dossier = resolver(doc.content.meta.dossier)
+    resolvedFields.format = resolver(doc.content.meta.format)
+  }
+
+  let credits = []
+  visit(doc.content, 'zone', node => {
+    if (node.identifier === 'TITLE') {
+      const paragraphs = node.children
+        .filter(child => child.type === 'paragraph')
+      if (paragraphs.length >= 2) {
+        credits = paragraphs[paragraphs.length - 1].children
+      }
+    }
+  })
+
+  doc._meta = {
+    ...doc.content.meta,
+    credits,
+    ...resolvedFields
+  }
+  return doc._meta
+}
+
+module.exports = {
+  getMeta
+}

--- a/packages/documents/lib/resolve.js
+++ b/packages/documents/lib/resolve.js
@@ -2,12 +2,16 @@ const checkEnv = require('check-env')
 const { parse } = require('url')
 
 checkEnv([
-  'GITHUB_LOGIN'
+  'GITHUB_LOGIN',
+  'FRONTEND_BASE_URL'
 ])
 
 const {
-  GITHUB_LOGIN
+  GITHUB_LOGIN,
+  FRONTEND_BASE_URL
 } = process.env
+
+const PUBLIC_HOSTNAME = parse(FRONTEND_BASE_URL).hostname
 
 const getRepoId = (url, requireQuery) => {
   if (!url) {
@@ -32,7 +36,52 @@ const getRepoId = (url, requireQuery) => {
   return pathSegments.join('/')
 }
 
-const createAutoSlug = allDocuments => url => {
+const userPath = /^\/~([^/?#]+)/
+
+const extractUserPath = path => {
+  if (!path) {
+    return
+  }
+  const match = String(path).match(userPath)
+  const id = match && match[1]
+  if (id) {
+    return {
+      id,
+      path
+    }
+  }
+}
+
+const extractUserUrl = url => {
+  if (!url) {
+    return
+  }
+  const urlObject = parse(String(url))
+  if (
+    urlObject.hostname &&
+    urlObject.hostname !== PUBLIC_HOSTNAME
+  ) {
+    // do nothing if url has a hostname and it's not ours
+    return
+  }
+  return extractUserPath(
+    `${urlObject.path}${urlObject.hash || ''}`
+  )
+}
+
+const createUrlReplacer = (allDocuments = [], usernames = []) => url => {
+  const userInfo = extractUserPath(url)
+  if (userInfo) {
+    const user = usernames
+      .find(u => u.id === userInfo.id)
+    if (user) {
+      return userInfo.path.replace(
+        user.id,
+        user.username
+      )
+    }
+  }
+
   const repoId = getRepoId(url, 'autoSlug')
   if (!repoId) {
     return url
@@ -62,5 +111,6 @@ const createResolver = allDocuments => url => {
 
 module.exports = {
   createResolver,
-  createAutoSlug
+  createUrlReplacer,
+  extractUserUrl
 }

--- a/packages/documents/lib/resolve.js
+++ b/packages/documents/lib/resolve.js
@@ -1,0 +1,66 @@
+const checkEnv = require('check-env')
+const { parse } = require('url')
+
+checkEnv([
+  'GITHUB_LOGIN'
+])
+
+const {
+  GITHUB_LOGIN
+} = process.env
+
+const getRepoId = (url, requireQuery) => {
+  if (!url) {
+    return
+  }
+  const {
+    hostname,
+    pathname,
+    query
+  } = parse(String(url))
+  const pathSegments = pathname.split('/').filter(Boolean)
+  if (
+    hostname !== 'github.com' ||
+    pathSegments.length !== 2 ||
+    pathSegments[0] !== GITHUB_LOGIN
+  ) {
+    return
+  }
+  if (requireQuery && query !== requireQuery) {
+    return
+  }
+  return pathSegments.join('/')
+}
+
+const createAutoSlug = allDocuments => url => {
+  const repoId = getRepoId(url, 'autoSlug')
+  if (!repoId) {
+    return url
+  }
+  const linkedDoc = allDocuments
+    .find(d => d.repoId === repoId)
+  if (linkedDoc) {
+    return `/${linkedDoc.content.meta.slug}`
+  }
+  // autoSlug links pointing to
+  // not published or missing documents are stripped
+  return ''
+}
+
+const createResolver = allDocuments => url => {
+  const repoId = getRepoId(url)
+  if (!repoId) {
+    return null
+  }
+  const linkedDoc = allDocuments
+    .find(d => d.repoId === repoId)
+  if (linkedDoc) {
+    return linkedDoc
+  }
+  return null
+}
+
+module.exports = {
+  createResolver,
+  createAutoSlug
+}

--- a/packages/documents/package.json
+++ b/packages/documents/package.json
@@ -23,10 +23,11 @@
     "isomorphic-unfetch": "^2.0.0"
   },
   "dependencies": {
-    "apollo-modules-node": "^0.1.1",
     "@orbiting/backend-modules-auth": "^2.2.0",
+    "apollo-modules-node": "^0.1.1",
     "check-env": "^1.3.0",
-    "d3-array": "^1.2.1"
+    "d3-array": "^1.2.1",
+    "unist-util-visit": "^1.3.0"
   },
   "peerDependencies": {
     "isomorphic-unfetch": "^2.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5276,6 +5276,16 @@ uniq@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/uniq/-/uniq-1.0.1.tgz#b31c5ae8254844a3a8281541ce2b04b865a734ff"
 
+unist-util-is@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/unist-util-is/-/unist-util-is-2.1.1.tgz#0c312629e3f960c66e931e812d3d80e77010947b"
+
+unist-util-visit@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/unist-util-visit/-/unist-util-visit-1.3.0.tgz#41ca7c82981fd1ce6c762aac397fc24e35711444"
+  dependencies:
+    unist-util-is "^2.1.1"
+
 universalify@^0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/universalify/-/universalify-0.1.1.tgz#fa71badd4437af4c148841e3b3b165f9e9e590b7"


### PR DESCRIPTION
Features:
- Links to other documents (saved as github.com links) are resolved to the published document
  when marked with `?autoSlug` replaced in place, and to full queryable documents for `meta.dossier` and `meta.format`
- Links to user profile with ids (saved with the correct front end path or absolute path) are looked up and replaced with the username, if found and public.
- New `documents` filter: `dossier`, `format` and `template`
- enforce valid characters in `checkUsername`

Additionally all meta data normalization logic from publikator was moved here. 

publikator tests pass:
```
1..848
# tests 848
# pass  848

# ok

✨  Done in 328.30s.
```