### PR TITLE
report unresolvable repoIds in document content and meta resolvers

### DIFF
--- a/packages/documents/graphql/resolvers/Document.js
+++ b/packages/documents/graphql/resolvers/Document.js
@@ -1,6 +1,6 @@
-const visit = require('unist-util-visit')
 const {
-  createUrlReplacer
+  contentUrlResolver,
+  metaUrlResolver
 } = require('../../lib/resolve')
 const { getMeta } = require('../../lib/meta')
 
@@ -11,35 +11,14 @@ module.exports = {
     // - alt check info.path for documents / document being the root
     //   https://gist.github.com/tpreusse/f79833a023706520da53647f9c61c7f6
     if (doc._all) {
-      const urlReplacer = createUrlReplacer(
-        doc._all,
-        doc._usernames
-      )
-
-      visit(doc.content, 'link', node => {
-        node.url = urlReplacer(node.url)
-      })
-      visit(doc.content, 'zone', node => {
-        if (node.data) {
-          node.data.url = urlReplacer(node.data.url)
-        }
-      })
+      contentUrlResolver(doc, doc._all, doc._usernames)
     }
-
     return doc.content
   },
   meta (doc, args, context, info) {
     const meta = getMeta(doc)
     if (doc._all) {
-      const urlReplacer = createUrlReplacer(
-        doc._all,
-        doc._usernames
-      )
-      meta.credits
-        .filter(c => c.type === 'link')
-        .forEach(c => {
-          c.url = urlReplacer(c.url)
-        })
+      metaUrlResolver(meta, doc._all, doc._usernames)
     }
     return meta
   }

--- a/packages/documents/graphql/resolvers/_queries/documents.js
+++ b/packages/documents/graphql/resolvers/_queries/documents.js
@@ -25,7 +25,6 @@ module.exports = async (_, args, { user, redis, pgdb }) => {
     ? 'prepublication'
     : 'publication'
 
-  const repoIds = await redis.smembersAsync('repos:ids')
   const {
     feed,
     userId,
@@ -37,158 +36,177 @@ module.exports = async (_, args, { user, redis, pgdb }) => {
     before,
     last,
     path,
-    repoId
+    repoId,
+    scheduledAt
   } = args
 
-  return Promise.all(
-    repoIds.map(repoId => {
-      return redis.getAsync(`repos:${repoId}/${ref}`)
-        .then(publication => {
-          const json = JSON.parse(publication)
-          if (!json) {
-            return null
-          }
-          return {
-            repoId,
-            id: Buffer.from(`repo:${repoId}`).toString('base64'),
-            ...json.doc
-          }
-        })
-    })
-  )
-    .then(async docs => {
-      const allDocuments = docs.filter(Boolean)
-      const userIds = []
-      allDocuments.forEach(doc => {
-        visit(doc.content, 'link', node => {
-          const info = extractUserUrl(node.url)
-          if (info) {
-            node.url = info.path
-            if(isUUID.v4(info.id)) {
-              userIds.push(info.id)
-            } else {
-              debug('documents found nonUUID %s in repo %s', info.id, doc.repoId)
-            }
-          }
-        })
-      })
-      const usernames = userIds.length
-        ? await pgdb.public.users.find(
-          {
-            id: userIds,
-            hasPublicProfile: true,
-            'username !=': null
-          },
-          {
-            fields: ['id', 'username']
-          }
-        )
-        : []
-      allDocuments.forEach(doc => {
-        // expose all documents to each document
-        // for link resolving in lib/resolve
-        // - including the usernames
-        doc._all = allDocuments
-        doc._usernames = usernames
-      })
+  const repoIds = await redis.smembersAsync('repos:ids')
 
-      let documents = allDocuments
-      if (feed) {
-        documents = documents.filter(d => (
-          d.content.meta.feed ||
-          (d.content.meta.feed === undefined && d.content.meta.template === 'article')
-        ))
-      }
-      if (userId) {
-        documents = documents.filter(d => {
-          const userIds = (getMeta(d).credits || [])
-            .filter(c => c.type === 'link')
-            .map(c => c.url.split('~')[1])
-            .filter(Boolean)
-          return userIds.includes(userId)
-        })
-      }
-      if (dossierId) {
-        documents = documents.filter(d => {
-          const dossier = getMeta(d).dossier
-          return dossier && (
-            dossier.id === dossierId ||
-            dossier.repoId === dossierId
-          )
-        })
-      }
-      if (formatId) {
-        documents = documents.filter(d => {
-          const format = getMeta(d).format
-          return format && (
-            format.id === formatId ||
-            format.repoId === formatId
-          )
-        })
-      }
-      if (path) {
-        documents = documents.filter(d => (
-          d.content.meta.path === path ||
-          '/'+d.content.meta.slug === path
-        ))
-      }
-      if (repoId) {
-        documents = documents.filter(d =>
-          d.repoId === repoId
-        )
-      }
-      if (template) {
-        documents = documents.filter(d => (
-          d.content.meta.template === template
-        ))
+  const docs = await Promise.all(
+    repoIds.map( async repoId => {
+      let publication
+      if (scheduledAt) {
+        const score = await redis.zscoreAsync('repos:scheduledIds', `repos:${repoId}/scheduled-publication`)
+        const repoScheduledAt = score
+          ? new Date(parseInt(score))
+          : null
+
+        const scheduledDocument = repoScheduledAt
+          ? await redis.getAsync(`repos:${repoId}/scheduled-publication`)
+          : null
+
+        if (scheduledDocument && repoScheduledAt <= scheduledAt) {
+          publication = scheduledDocument
+        }
       }
 
-      documents = documents.sort((a, b) =>
-        descending(new Date(a.content.meta.publishDate), new Date(b.content.meta.publishDate))
-      )
-
-      let readNodes = true
-      // we only restrict the nodes array
-      // making totalCount always available
-      // - querying a single document by path is always allowed
-      if (DOCUMENTS_RESTRICT_TO_ROLES && !path && !repoId) {
-        const roles = DOCUMENTS_RESTRICT_TO_ROLES.split(',')
-        readNodes = userIsInRoles(user, roles)
+      if (!publication) {
+        publication = await redis.getAsync(`repos:${repoId}/${ref}`)
       }
-
-      let startIndex = 0
-      let endIndex = documents.length
-      if (after) {
-        startIndex = documents.findIndex(node => node.id === after)
+      const json = JSON.parse(publication)
+      if (!json) {
+        return null
       }
-      if (before) {
-        endIndex = documents.findIndex(node => node.id === before)
-      }
-      if (first !== undefined) {
-        endIndex = startIndex + first
-      } else if (last !== undefined) {
-        startIndex = endIndex - last
-      }
-      const nodes = documents.slice(startIndex, endIndex)
-
-      const end = nodes[nodes.length - 1]
-      const start = nodes[0]
 
       return {
-        totalCount: documents.length,
-        nodes: readNodes
-          ? nodes
-          : [],
-        pageInfo: {
-          endCursor: readNodes
-            ? end && end.id
-            : undefined,
-          hasNextPage: endIndex < documents.length - 1,
-          hasPreviousPage: startIndex > 0,
-          startCursor: readNodes
-            ? start && start.id
-            : undefined
+        repoId,
+        id: Buffer.from(`repo:${repoId}`).toString('base64'),
+        ...json.doc
+      }
+    })
+  )
+
+  const allDocuments = docs.filter(Boolean)
+  const userIds = []
+  allDocuments.forEach(doc => {
+    visit(doc.content, 'link', node => {
+      const info = extractUserUrl(node.url)
+      if (info) {
+        node.url = info.path
+        if(isUUID.v4(info.id)) {
+          userIds.push(info.id)
+        } else {
+          debug('documents found nonUUID %s in repo %s', info.id, doc.repoId)
         }
       }
     })
+  })
+  const usernames = userIds.length
+    ? await pgdb.public.users.find(
+      {
+        id: userIds,
+        hasPublicProfile: true,
+        'username !=': null
+      },
+      {
+        fields: ['id', 'username']
+      }
+    )
+    : []
+  allDocuments.forEach(doc => {
+    // expose all documents to each document
+    // for link resolving in lib/resolve
+    // - including the usernames
+    doc._all = allDocuments
+    doc._usernames = usernames
+  })
+
+  let documents = allDocuments
+  if (feed) {
+    documents = documents.filter(d => (
+      d.content.meta.feed ||
+      (d.content.meta.feed === undefined && d.content.meta.template === 'article')
+    ))
+  }
+  if (userId) {
+    documents = documents.filter(d => {
+      const userIds = (getMeta(d).credits || [])
+        .filter(c => c.type === 'link')
+        .map(c => c.url.split('~')[1])
+        .filter(Boolean)
+      return userIds.includes(userId)
+    })
+  }
+  if (dossierId) {
+    documents = documents.filter(d => {
+      const dossier = getMeta(d).dossier
+      return dossier && (
+        dossier.id === dossierId ||
+        dossier.repoId === dossierId
+      )
+    })
+  }
+  if (formatId) {
+    documents = documents.filter(d => {
+      const format = getMeta(d).format
+      return format && (
+        format.id === formatId ||
+        format.repoId === formatId
+      )
+    })
+  }
+  if (path) {
+    documents = documents.filter(d => (
+      d.content.meta.path === path ||
+      '/'+d.content.meta.slug === path
+    ))
+  }
+  if (repoId) {
+    documents = documents.filter(d =>
+      d.repoId === repoId
+    )
+  }
+  if (template) {
+    documents = documents.filter(d => (
+      d.content.meta.template === template
+    ))
+  }
+
+  documents = documents.sort((a, b) =>
+    descending(new Date(a.content.meta.publishDate), new Date(b.content.meta.publishDate))
+  )
+
+  let readNodes = true
+  // we only restrict the nodes array
+  // making totalCount always available
+  // - querying a single document by path is always allowed
+  if (DOCUMENTS_RESTRICT_TO_ROLES && !path && !repoId) {
+    const roles = DOCUMENTS_RESTRICT_TO_ROLES.split(',')
+    readNodes = userIsInRoles(user, roles)
+  }
+
+  let startIndex = 0
+  let endIndex = documents.length
+  if (after) {
+    startIndex = documents.findIndex(node => node.id === after)
+  }
+  if (before) {
+    endIndex = documents.findIndex(node => node.id === before)
+  }
+  if (first !== undefined) {
+    endIndex = startIndex + first
+  } else if (last !== undefined) {
+    startIndex = endIndex - last
+  }
+  const nodes = documents.slice(startIndex, endIndex)
+
+  const end = nodes[nodes.length - 1]
+  const start = nodes[0]
+
+  return {
+    totalCount: documents.length,
+    nodes: readNodes
+      ? nodes
+      : [],
+    pageInfo: {
+      endCursor: readNodes
+        ? end && end.id
+        : undefined,
+      hasNextPage: endIndex < documents.length - 1,
+      hasPreviousPage: startIndex > 0,
+      startCursor: readNodes
+        ? start && start.id
+        : undefined
+    }
+  }
 }

--- a/packages/documents/lib/meta.js
+++ b/packages/documents/lib/meta.js
@@ -1,21 +1,15 @@
 const visit = require('unist-util-visit')
-const { createResolver } = require('./resolve')
+const { metaFieldResolver } = require('./resolve')
 
 const getMeta = doc => {
   if (doc._meta) {
     return doc._meta
   }
 
-  const resolvedFields = {}
-
   // see _all note in Document.content resolver
-  if (doc._all) {
-    const resolver = createResolver(doc._all)
-
-    resolvedFields.dossier = resolver(doc.content.meta.dossier)
-    resolvedFields.format = resolver(doc.content.meta.format)
-    resolvedFields.discussion = resolver(doc.content.meta.discussion)
-  }
+  const resolvedFields = doc._all
+    ? metaFieldResolver(doc.content.meta, doc._all)
+    : { }
 
   let credits = []
   visit(doc.content, 'zone', node => {


### PR DESCRIPTION
credit: most of it done in pair programming with @tpreusse 

affects: @orbiting/backend-modules-documents

- extract content and meta resolvers into lib and export
- documents query honours scheduled documents for _all if arg scheduledAt is set
  