### PR TITLE
Don't await sign-In hooks in authorizeSession

### DIFF
--- a/packages/auth/lib/Sessions.js
+++ b/packages/auth/lib/Sessions.js
@@ -109,13 +109,15 @@ const authorizeSession = async ({ pgdb, token, emailFromQuery, signInHooks = [] 
   })
 
   // call signIn hooks
-  Promise.all(
-    signInHooks.map(hook =>
-      hook(user.id, !existingUser, pgdb)
+  try {
+    await Promise.all(
+      signInHooks.map(hook =>
+        hook(user.id, !existingUser, pgdb)
+      )
     )
-  ).catch((e) => {
+  } catch (e) {
     console.warn(`sign in hook failed in authorizeSession`, e)
-  })
+  }
 
   return user
 }

--- a/packages/auth/lib/Sessions.js
+++ b/packages/auth/lib/Sessions.js
@@ -109,11 +109,13 @@ const authorizeSession = async ({ pgdb, token, emailFromQuery, signInHooks = [] 
   })
 
   // call signIn hooks
-  await Promise.all(
+  Promise.all(
     signInHooks.map(hook =>
       hook(user.id, !existingUser, pgdb)
     )
-  )
+  ).catch((e) => {
+    console.warn(`sign in hook failed in authorizeSession`, e)
+  })
 
   return user
 }


### PR DESCRIPTION
Random smtp or 3rd party API errors should not lead to thrown error in authorizeSession resolver