### PR TITLE
fix: bug in series resolver (cannot read series of undefined)

### DIFF
--- a/packages/documents/lib/resolve.js
+++ b/packages/documents/lib/resolve.js
@@ -165,7 +165,7 @@ const metaFieldResolver = (meta, allDocuments = [], errors) => {
   // string, aka github url if this document belongs to a series
   if (typeof series === 'string') {
     const seriesDocument = resolver(meta.series)
-    series = seriesDocument && seriesDocument.meta && seriesDocument.meta.series
+    series = seriesDocument && seriesDocument.content.meta.series
   }
   if (series) {
     series = {

--- a/packages/documents/lib/resolve.js
+++ b/packages/documents/lib/resolve.js
@@ -165,7 +165,7 @@ const metaFieldResolver = (meta, allDocuments = [], errors) => {
   // string, aka github url if this document belongs to a series
   if (typeof series === 'string') {
     const seriesDocument = resolver(meta.series)
-    series = seriesDocument && seriesDocument.meta.series
+    series = seriesDocument && seriesDocument.meta && seriesDocument.meta.series
   }
   if (series) {
     series = {


### PR DESCRIPTION
Fixes below error which happens 
1. when publishing an episode (slave) article in publikator and 
2. when retrieving slave articles in republik-backend.

```
error in graphql { TypeError: Cannot read property 'series' of undefined
    at metaFieldResolver (/Users/daniel/work/republik-backend/node_modules/@orbiting/backend-modules-documents/lib/resolve.js:168:52)
    at getMeta (/Users/daniel/work/republik-backend/node_modules/@orbiting/backend-modules-documents/lib/meta.js:11:7)
    at meta (/Users/daniel/work/republik-backend/node_modules/@orbiting/backend-modules-documents/graphql/resolvers/Document.js:19:18)
```

Tested fix locally.